### PR TITLE
fix: Update actions/upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './dist-demo'
 


### PR DESCRIPTION
This updates the actions/upload-pages-artifact from v2 to v3 to resolve the deprecation error caused by an older version of actions/upload-artifact being used as a dependency.